### PR TITLE
Include Pipe.jl in the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 František Navrkal
+Copyright (c) 2015 Lyndon White (Pipe.jl)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
By the MIT License which Pipe.jl was released under,
my copyright line needs to "be included in all copies or substantial portions of the Software."

So this PR fixes that.

----

I am pleased with your fork.
It adds a feature that I will never add the Pipe.jl
because I don't personally like it,
but I know lots of people, especially various Universal Calling Convention and LINQish affectionardos do
So it is good to give people the option.

I have added this to my big list of similar packages

https://github.com/JuliaLang/julia/issues/5571#issuecomment-205754539
